### PR TITLE
Path example bug

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs.js
+++ b/cloudwatchlogs/cloudwatchlogs.js
@@ -8,7 +8,7 @@ exports.handler = function(event, context) {
 		// See more at: https://service.sumologic.com/help/Default.htm#Collector_Management_API.htm
 		///////////////////////////////////////////////////////////////////////////////////////////////////////////
 	    var options = { 'hostname': 'collectors.sumologic.com',
-						'path': 'https://collectors.sumologic.com/receiver/v1/http/<XXX>',
+						'path': 'receiver/v1/http/<XXX>',
 						'method': 'POST'
 					};
 		var zippedInput = new Buffer(event.awslogs.data, 'base64');

--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -8,7 +8,7 @@ exports.handler = function(event, context) {
 		///////////////////////////////////////////////////////////////////////////////////////////////////////////
 		var options = {
 			'hostname': 'collectors.sumologic.com',
-			'path': 'https://collectors.sumologic.com/receiver/v1/http/<XXX>',
+			'path': 'receiver/v1/http/<XXX>',
 			'method': 'POST'
 		};
 		var zippedInput = new Buffer(event.awslogs.data, 'base64');


### PR DESCRIPTION
Since you're making a request via [`https.request`](https://nodejs.org/api/https.html#https_https_request_options_callback), the `path` option should be a path, not the full URL. The example is just a tad confusing, since it's listing the full URL.