### PR TITLE
Fix undefined errors var when http status != 200

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -118,7 +118,7 @@ function postToSumo(context, messages) {
                 if (res.statusCode == 200) {
                     messagesSent++;
                 } else {
-                    errors.push('HTTP Return code ' + res.statusCode);
+                    messageErrors.push('HTTP Return code ' + res.statusCode);
                 }
                 finalizeContext();
             });


### PR DESCRIPTION
* When data is posted but returns a statusCode != 200 an error was being
  pushed into an undefined var errors
* Change pushes the error in to the messageErrors var instead