### PR TITLE
Fixed multi-line console log parsing

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -21,7 +21,7 @@ var includeLogInfo = true;  // default is true
 // Regex used to detect logs coming from lambda functions.
 // The regex will parse out the requestID and strip the timestamp
 // Example: 2016-11-10T23:11:54.523Z	108af3bb-a79b-11e6-8bd7-91c363cc05d9    some message
-var consoleFormatRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\t(\w+?-\w+?-\w+?-\w+?-\w+)\t(.*)/;
+var consoleFormatRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\t(\w+?-\w+?-\w+?-\w+?-\w+)\t/;
 
 // Used to extract RequestID
 var requestIdRegex = /(?:RequestId:|Z)\s+([\w\d\-]+)/;
@@ -179,7 +179,7 @@ exports.handler = function (event, context) {
             var consoleLog = consoleFormatRegex.exec(log.message);
             if (consoleLog !== null) {
                 lastRequestID = consoleLog[1];
-                log.message = consoleLog[2].trim();
+                log.message = log.message.substring(consoleLog[0].length);
             }
             
             // Auto detect if message is json


### PR DESCRIPTION
Some of our lambda log messages span multiple lines. We'll often log formatted JSON strings. Only the first line was being picked up by the regex. I've been testing this internally and it picks up single-line and multi-line messages.