### PR TITLE
Mapping sourcehost and sourcename more accurately from cloudwatch log…

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -46,13 +46,13 @@ function sumoMetaKey(awslogsData, message) {
     if (sourceHostOverride !== null && sourceHostOverride !== '' && sourceHostOverride != 'none') {
         sourceHost = sourceHostOverride;
     } else {
-        sourceHost = awslogsData.logGroup;
+        sourceHost = awslogsData.logStream;
     }
     
     if (sourceNameOverride !== null && sourceNameOverride !== '' && sourceNameOverride != 'none') {
         sourceName = sourceNameOverride;
     } else {
-        sourceName = awslogsData.logStream;
+        sourceName = awslogsData.logGroup;
     }
     
     // Ability to override metadata within the message


### PR DESCRIPTION
As I read the Sumologic description of [Source Host](https://help.sumologic.com/Send-Data/Sources/04Reference-Information-for-Sources/Metadata-Naming-Conventions#Source_Host) and [Source Name](https://help.sumologic.com/Send-Data/Sources/04Reference-Information-for-Sources/Metadata-Naming-Conventions#Source_Name) compared to [Amazon CloudWatch Logs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogsConcepts.html) description of Log Streams and Log Groups, Source Host seems to map much better to a Log Stream, and Source Name seems to map much better to a Log Group:

Source Host: "...Sumo Logic recommends that you carefully select a meaningful name that uniquely identifies the host from which data is collected..."
Log Stream: "...a log stream is generally intended to represent the sequence of events coming from the application instance or resource..."

Source Name: "... the file path entered when you created your Source..."
Log Group: "...a typical log group organization for a fleet of Apache web servers could be the following: MyWebsite.com/Apache/access_log, or MyWebsite.com/Apache/error_log..."

I understand swapping this would probably mess with many clients' queries if they actually consumed it, so I don't have a problem forking this for our own purposes.

But we are wondering why it wouldn't be mapped like this? What is the logic?