### PR TITLE
removed default behavior of overriding host/source with loggroup

### DIFF
--- a/dlq_processor/DLQLambdaCloudFormation.json
+++ b/dlq_processor/DLQLambdaCloudFormation.json
@@ -249,7 +249,7 @@
             "Type":"AWS::SNS::Topic",
             "Properties":{
                 "Subscription":[ {
-                    "Endpoint" : "hpal@sumologic.com",
+                    "Endpoint" : "test@gmail.com",
                     "Protocol" : "email"
                 }]
             }

--- a/dlq_processor/Readme.md
+++ b/dlq_processor/Readme.md
@@ -40,8 +40,8 @@ exports.handler = (event, context, callback) => {
         'message': 'something happened..',
         '_sumo_metadata': {
             'category': 'prod/appa/console',
-            'source': 'other_source',
-            'host': serverIp
+            'sourceName': 'other_source',
+            'sourceHost': serverIp
         }
 
     }));

--- a/dlq_processor/Readme.md
+++ b/dlq_processor/Readme.md
@@ -23,6 +23,32 @@ The following AWS Lambda environment variables are supported in both the lambda 
 SumoCWProcessDLQLambda supports one extra environment variable
 * NUM_OF_WORKERS(REQUIRED): It’s default value is 4. It controls the number of instances of SumoCWProcessDLQLambda to spawn if there is no failure in first attempt.It helps in faster processing of pending messages in dead letter queue.
 
+# Dynamic Metadata Fields
+
+The lambda supports dynamically overriding the _sourceName, _sourceHost and _sourceCategory per log message by setting `_sumo_metadata` within a json log.
+
+This can be useful when writing to CloudWatch Logs via a lambda function.
+
+For example:
+
+```
+exports.handler = (event, context, callback) => {
+
+    var serverIp = '123.123.123.123'
+
+    console.log(JSON.stringify({
+        'message': 'something happened..',
+        '_sumo_metadata': {
+            'category': 'prod/appa/console',
+            'source': 'other_source',
+            'host': serverIp
+        }
+
+    }));
+    console.log('some other log message with default sourceCategory');
+};
+
+```
 
 ### For Developers
 

--- a/dlq_processor/cloudwatchlogs_lambda.js
+++ b/dlq_processor/cloudwatchlogs_lambda.js
@@ -31,7 +31,7 @@ function getConfig(env, errorHandler) {
         // SumoLogic Endpoint to post logs
         "SumoURL": env.SUMO_ENDPOINT,
 
-        // The following parameters override the sourceCategoryOverride, sourceHostOverride and sourceNameOverride metadata fields within SumoLogic.
+        // The following parameters override the sourceCategory, sourceHost and sourceName metadata fields within SumoLogic.
         // Not these can also be overridden via json within the message payload. See the README for more information.
         "sourceCategoryOverride": ("SOURCE_CATEGORY_OVERRIDE" in env) ?  env.SOURCE_CATEGORY_OVERRIDE: '',  // If none sourceCategoryOverride will not be overridden
         "sourceHostOverride": ("SOURCE_HOST_OVERRIDE" in env) ? env.SOURCE_HOST_OVERRIDE : '',          // If none sourceHostOverride will not be set to the name of the logGroup

--- a/dlq_processor/cloudwatchlogs_lambda.js
+++ b/dlq_processor/cloudwatchlogs_lambda.js
@@ -33,9 +33,9 @@ function getConfig(env, errorHandler) {
 
         // The following parameters override the sourceCategoryOverride, sourceHostOverride and sourceNameOverride metadata fields within SumoLogic.
         // Not these can also be overridden via json within the message payload. See the README for more information.
-        "sourceCategoryOverride": env.SOURCE_CATEGORY_OVERRIDE || 'none',  // If none sourceCategoryOverride will not be overridden
-        "sourceHostOverride": env.SOURCE_HOST_OVERRIDE || 'none',          // If none sourceHostOverride will not be set to the name of the logGroup
-        "sourceNameOverride": env.SOURCE_NAME_OVERRIDE || 'none',          // If none sourceNameOverride will not be set to the name of the logStream
+        "sourceCategoryOverride": ("SOURCE_CATEGORY_OVERRIDE" in env) ?  env.SOURCE_CATEGORY_OVERRIDE: 'none',  // If none sourceCategoryOverride will not be overridden
+        "sourceHostOverride": ("SOURCE_HOST_OVERRIDE" in env) ? env.SOURCE_HOST_OVERRIDE : 'none',          // If none sourceHostOverride will not be set to the name of the logGroup
+        "sourceNameOverride": ("SOURCE_NAME_OVERRIDE" in env) ? env.SOURCE_NAME_OVERRIDE : 'none',          // If none sourceNameOverride will not be set to the name of the logStream
         "SUMO_CLIENT_HEADER": env.SUMO_CLIENT_HEADER || 'cwl-aws-lambda',
         // CloudWatch logs encoding
         "encoding": env.ENCODING || 'utf-8'  // default is utf-8
@@ -129,12 +129,18 @@ exports.processLogs = function (env, eventAwslogsData, errorHandler) {
         // Push messages to Sumo
         SumoLogsClientObj.postToSumo(messageList, errorHandler, function (options, messages, key) {
             var headerArray = key.split(':');
-            options.headers = {
+            var headers = {
                 'X-Sumo-Name': headerArray[0],
                 'X-Sumo-Category': headerArray[1],
                 'X-Sumo-Host': headerArray[2],
                 'X-Sumo-Client': config.SUMO_CLIENT_HEADER
             };
+            // removing headers with 'none'
+            for (var key in headers) {
+                if (headers[key] === 'none')
+                    delete headers[key]
+            }
+            options.headers = headers
         });
     };
     var uncompressed_bytes = [];

--- a/dlq_processor/cloudwatchlogs_lambda.js
+++ b/dlq_processor/cloudwatchlogs_lambda.js
@@ -33,9 +33,9 @@ function getConfig(env, errorHandler) {
 
         // The following parameters override the sourceCategoryOverride, sourceHostOverride and sourceNameOverride metadata fields within SumoLogic.
         // Not these can also be overridden via json within the message payload. See the README for more information.
-        "sourceCategoryOverride": ("SOURCE_CATEGORY_OVERRIDE" in env) ?  env.SOURCE_CATEGORY_OVERRIDE: 'none',  // If none sourceCategoryOverride will not be overridden
-        "sourceHostOverride": ("SOURCE_HOST_OVERRIDE" in env) ? env.SOURCE_HOST_OVERRIDE : 'none',          // If none sourceHostOverride will not be set to the name of the logGroup
-        "sourceNameOverride": ("SOURCE_NAME_OVERRIDE" in env) ? env.SOURCE_NAME_OVERRIDE : 'none',          // If none sourceNameOverride will not be set to the name of the logStream
+        "sourceCategoryOverride": ("SOURCE_CATEGORY_OVERRIDE" in env) ?  env.SOURCE_CATEGORY_OVERRIDE: '',  // If none sourceCategoryOverride will not be overridden
+        "sourceHostOverride": ("SOURCE_HOST_OVERRIDE" in env) ? env.SOURCE_HOST_OVERRIDE : '',          // If none sourceHostOverride will not be set to the name of the logGroup
+        "sourceNameOverride": ("SOURCE_NAME_OVERRIDE" in env) ? env.SOURCE_NAME_OVERRIDE : '',          // If none sourceNameOverride will not be set to the name of the logStream
         "SUMO_CLIENT_HEADER": env.SUMO_CLIENT_HEADER || 'cwl-aws-lambda',
         // CloudWatch logs encoding
         "encoding": env.ENCODING || 'utf-8'  // default is utf-8
@@ -137,7 +137,7 @@ exports.processLogs = function (env, eventAwslogsData, errorHandler) {
             };
             // removing headers with 'none'
             for (var key in headers) {
-                if (headers[key] === 'none')
+                if (!headers[key] || (headers[key].toLowerCase() === 'none'))
                     delete headers[key]
             }
             options.headers = headers

--- a/dlq_processor/package.json
+++ b/dlq_processor/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {},
   "scripts": {
     "test": "node -e 'require('./test').test()'",
-    "build": "zip -r dlqprocessor.zip DLQProcessor.js cloudwatchlogs_lambda.js package.json sumo-dlq-function-utils/ node_modules/",
+    "build": "rm -f dlqprocessor.zip && zip -r dlqprocessor.zip DLQProcessor.js cloudwatchlogs_lambda.js package.json sumo-dlq-function-utils/",
     "prod_deploy": "python -c 'from test_cwl_lambda import prod_deploy;prod_deploy()'"
   },
   "author": "Himanshu Pal",

--- a/dlq_processor/test_cwl_lambda.py
+++ b/dlq_processor/test_cwl_lambda.py
@@ -25,7 +25,7 @@ class TestLambda(unittest.TestCase):
         self.template_name = 'DLQLambdaCloudFormation.json'
         self.template_data = self._parse_template(self.template_name)
         # replacing prod zipfile location to test zipfile location
-        self.template_data.replace("appdevzipfiles", BUCKET_PREFIX, 1)
+        self.template_data.replace("appdevzipfiles", BUCKET_PREFIX)
 
     def tearDown(self):
         if self.stack_exists(self.stack_name):
@@ -205,6 +205,8 @@ def generate_fixtures(region, count):
 
 
 def prod_deploy():
+    global BUCKET_PREFIX
+    BUCKET_PREFIX = 'appdevzipfiles'
     upload_code_in_multiple_regions()
     print("Uploading template file in S3")
     s3 = boto3.client('s3', "us-east-1")

--- a/loggroup-lambda-connector/package.json
+++ b/loggroup-lambda-connector/package.json
@@ -9,7 +9,8 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "zip -r loggroup-lambda-connector.zip loggroup-lambda-connector.js package.json node_modules/"
+    "build": "rm -f loggroup-lambda-connector.zip && zip -r loggroup-lambda-connector.zip loggroup-lambda-connector.js package.json",
+    "prod_deploy": "python -c 'from test_loggroup_lambda_connector import prod_deploy;prod_deploy()'"
   },
   "keywords": [
     "AWS"

--- a/loggroup-lambda-connector/test_loggroup_lambda_connector.py
+++ b/loggroup-lambda-connector/test_loggroup_lambda_connector.py
@@ -256,6 +256,19 @@ def upload_code_in_S3(region):
                    ExtraArgs={'ACL': 'public-read'})
 
 
+def prod_deploy():
+    global BUCKET_PREFIX
+    BUCKET_PREFIX = 'appdevzipfiles'
+    upload_code_in_multiple_regions()
+    print("Uploading template file in S3")
+    s3 = boto3.client('s3', "us-east-1")
+    filename = 'loggroup-lambda-cft.json'
+    bucket_name = "appdev-cloudformation-templates"
+    s3.upload_file(filename, bucket_name, filename,
+                   ExtraArgs={'ACL': 'public-read'})
+    print("Deployment Successfull: ALL files copied to Sumocontent")
+
+
 if __name__ == '__main__':
 
     if len(sys.argv) > 1:


### PR DESCRIPTION
Currently when the user does not specifies header in environment variables
they are set to none and sent to sumo.
If we set the default to ""  though it solves the problem but sourcename/hostname are overridden with loggroup and logstream. but what if customer does not want this behaviour.
This PR imposes following flow
1) If none of the headers are specified in environment variables or are set to 'none'.
source name, source host, source category headers won't be sent to sumo.

2) If SOURCE_CATEGORY_OVERRIDE/SOURCE_HOST_OVERRIDE/SOURCE_NAME_OVERRIDE are specified but are set to empty.
hostname and source name are replaced by loggroup/logstream respectively. All the three headers are sent to sumo.

3) If SOURCE_CATEGORY_OVERRIDE/SOURCE_HOST_OVERRIDE/SOURCE_NAME_OVERRIDE have some non empty value
They will be sent to sumo with defined overrides but they can overridden by Dynamic Metadata Fields(checkout readme for more info).
