### PR TITLE
Fix Regex for Console Format. Fix Message trim.

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -24,7 +24,7 @@ var includeLogInfo = true;  // default is true
 // Regex used to detect logs coming from lambda functions.
 // The regex will parse out the requestID and strip the timestamp
 // Example: 2016-11-10T23:11:54.523Z	108af3bb-a79b-11e6-8bd7-91c363cc05d9    some message
-var consoleFormatRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\t(\w+?-\w+?-\w+?-\w+?-\w+)\t/;
+var consoleFormatRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\s(\w+?-\w+?-\w+?-\w+?-\w+)\s/;
 
 // Used to extract RequestID
 var requestIdRegex = /(?:RequestId:|Z)\s+([\w\d\-]+)/;
@@ -188,7 +188,7 @@ exports.handler = function (event, context) {
                 log.message = JSON.parse(log.message);
             } catch (err) {
                 // Do nothing, leave as text
-                log.message.trim();
+                log.message = log.message.trim();
             }
             
             // delete id as it's not very useful


### PR DESCRIPTION
Regex was not parsing console messages as there are spaces and not tabs. Change regex to look for any whitespace.
Log message trim not being assigned back to the message.