### PR TITLE
Add outputs to DLQ lambda

### DIFF
--- a/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
+++ b/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
@@ -314,6 +314,15 @@
             },
             "DependsOn": ["SumoCWEmailSNSTopic"]
         }
+    },
+    "Outputs": {
+        "SumoCWLogsLambdaArn" : {
+            "Description": "The ARN of the sumologic cloudwatch logs lambda",
+            "Value" : { "Fn::GetAtt" : ["SumoCWLogsLambda", "Arn"] },
+            "Export" : {
+                "Name" : "SumoCWLogsLambdaArn"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Outputs the ARN for SumoCWLogsLambda so that it can be passed to a sibling cloudformation stack (e.g. loggroup-lambda-connector).