### PR TITLE
add ReservedConcurrentExecutions to CF templates

### DIFF
--- a/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
+++ b/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
@@ -28,6 +28,11 @@
         "Default": "false",
         "AllowedValues" : ["true" ,"false"],
         "Description": "Select true to get loggroup/logstream values in logs"
+      },
+      "Concurrency": {
+        "Type": "Number",
+        "Default": -1,
+        "Description": "Reserved concurrent executions for the lambdas. -1 for unreserved, 0 to stop the lambdas."
       }
     },
     "Mappings" : {
@@ -206,6 +211,7 @@
                     ]
                 },
                 "Timeout": 300,
+                "ReservedConcurrentExecutions": {"Ref": "Concurrency"},
                 "DeadLetterConfig": {
                     "TargetArn" : {
                         "Fn::GetAtt": [
@@ -267,6 +273,7 @@
                     ]
                 },
                 "Timeout": 300,
+                "ReservedConcurrentExecutions": {"Ref": "Concurrency"},
                 "Handler": "DLQProcessor.handler",
                 "DeadLetterConfig": {
                     "TargetArn" : {

--- a/loggroup-lambda-connector/sam/template.yaml
+++ b/loggroup-lambda-connector/sam/template.yaml
@@ -11,20 +11,25 @@ Globals:
 
 Parameters:
     LambdaARN:
-        Type : String
+        Type: String
         Default: "arn:aws:lambda:us-east-1:123456789000:function:TestLambda"
         Description: "Enter ARN for target lambda function"
 
     LogGroupPattern:
-        Type : String
+        Type: String
         Default: "Test"
         Description: "Enter regex for matching logGroups"
 
     UseExistingLogs:
-        Type : String
+        Type: String
         Default: "false"
-        AllowedValues : ["true", "false"]
+        AllowedValues: ["true", "false"]
         Description: "Select true for subscribing existing logs"
+
+    Concurrency:
+        Type: Number
+        Default: -1
+        Description: "Reserved concurrent executions for the lambdas. -1 for unreserved, 0 to stop the lambdas."
 
 Resources:
 
@@ -34,6 +39,7 @@ Resources:
         CodeUri: ../src/
         Handler: "loggroup-lambda-connector.handler"
         Runtime: nodejs8.10
+        ReservedConcurrentExecutions: !Ref "Concurrency"
         Environment:
           Variables:
             LAMBDA_ARN: !Ref "LambdaARN"


### PR DESCRIPTION
we found that running these three lambdas without [concurrency management](https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html) was causing us to hit CloudWatch API rate limits. the `Concurrency` parameters default to the `ReservedConcurrentExecutions`'s default, so this should be no change unless you set the `Concurrency` parameter(s)