### PR TITLE
Add log stream name prefix filtering, especially for AWS Batch logs

### DIFF
--- a/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
+++ b/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
@@ -28,6 +28,10 @@
         "Default": "false",
         "AllowedValues" : ["true" ,"false"],
         "Description": "Select true to get loggroup/logstream values in logs"
+      },
+      "LogStreamPrefix": {
+        "Type": "String",
+        "Description": "Enter comma separated list of logStream name prefixes to filter by logStream"
       }
     },
     "Mappings" : {
@@ -221,7 +225,8 @@
                     "Variables": {
                         "SUMO_ENDPOINT": {"Ref": "SumoEndPointURL"},
                         "LOG_FORMAT": {"Ref": "LogFormat"},
-                        "INCLUDE_LOG_INFO": {"Ref": "IncludeLogGroupInfo"}
+                        "INCLUDE_LOG_INFO": {"Ref": "IncludeLogGroupInfo"},
+                        "LOG_STREAM_PREFIX": {"Ref": "LogStreamPrefix"}
 
                     }
                 }
@@ -296,7 +301,8 @@
                         },
                         "NUM_OF_WORKERS": {"Ref": "NumOfWorkers"},
                         "LOG_FORMAT": {"Ref": "LogFormat"},
-                        "INCLUDE_LOG_INFO": {"Ref": "IncludeLogGroupInfo"}
+                        "INCLUDE_LOG_INFO": {"Ref": "IncludeLogGroupInfo"},
+                        "LOG_STREAM_PREFIX": {"Ref": "LogStreamPrefix"}
                     }
                 }
             }

--- a/cloudwatchlogs-with-dlq/Readme.md
+++ b/cloudwatchlogs-with-dlq/Readme.md
@@ -21,7 +21,7 @@ The following AWS Lambda environment variables are supported in both the lambda 
 * SOURCE_NAME_OVERRIDE (OPTIONAL) - Override _sourceName metadata field within SumoLogic.
 * INCLUDE_LOG_INFO (OPTIONAL) - Set it to true when loggroup/logstream values needs to be included in logs. Default is false
 * LOG_FORMAT - Default is Others. One can choose VPC-JSON for VPC flow logs in json format and VPC-RAW for only RAW message line
-* LOG_STREAM_PREFIX (OPTIONAL) - Comma separated list of logStream name prefixes to filter by logStream, expecially for AWS Batch logs
+* LOG_STREAM_PREFIX (OPTIONAL) - Comma separated list of logStream name prefixes to filter by logStream, especially for AWS Batch logs
 
 ### Configuring Lambda for VPC Flow Logs
 The following AWS Lambda environment variables are supported in both the lambda functions for VPC flow logs.

--- a/cloudwatchlogs-with-dlq/Readme.md
+++ b/cloudwatchlogs-with-dlq/Readme.md
@@ -21,6 +21,7 @@ The following AWS Lambda environment variables are supported in both the lambda 
 * SOURCE_NAME_OVERRIDE (OPTIONAL) - Override _sourceName metadata field within SumoLogic.
 * INCLUDE_LOG_INFO (OPTIONAL) - Set it to true when loggroup/logstream values needs to be included in logs. Default is false
 * LOG_FORMAT - Default is Others. One can choose VPC-JSON for VPC flow logs in json format and VPC-RAW for only RAW message line
+* LOG_STREAM_PREFIX (OPTIONAL) - Comma separated list of logStream name prefixes to filter by logStream, expecially for AWS Batch logs
 
 ### Configuring Lambda for VPC Flow Logs
 The following AWS Lambda environment variables are supported in both the lambda functions for VPC flow logs.

--- a/cloudwatchlogs-with-dlq/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs-with-dlq/cloudwatchlogs_lambda.js
@@ -85,7 +85,7 @@ function getConfig(env) {
         "includeSecurityGroupInfo": ("INCLUDE_SECURITY_GROUP_INFO" in env) ? env.INCLUDE_SECURITY_GROUP_INFO === "true" : false,
         // Regex to filter by logStream name prefixes
         "logStreamPrefixRegex": ("LOG_STREAM_PREFIX" in env)
-                                ? new RegExp('^(' + env.LOG_STREAM_PREFIX.replace(/,/g, '|')  + ')', 'i')
+                                ? new RegExp('^(' + escapeRegExp(env.LOG_STREAM_PREFIX).replace(/,/g, '|')  + ')', 'i')
                                 : ''
     };
     if (!config.SumoURL) {
@@ -97,6 +97,10 @@ function getConfig(env) {
         return new Error('Invalid SUMO_ENDPOINT environment variable: ' + config.SumoURL);
     }
     return config;
+}
+
+function escapeRegExp(string) {
+  return string.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
 }
 
 function transformRecords(config, records) {

--- a/cloudwatchlogs/README.md
+++ b/cloudwatchlogs/README.md
@@ -1,4 +1,4 @@
-# Sumo Logic Functions for AWS CloudWatch Logs 
+# Sumo Logic Functions for AWS CloudWatch Logs
 
 AWS Lambda function to collector logs from CloudWatch Logs and post them to [SumoLogic](http://www.sumologic.com) via a [HTTP collector endpoint](http://help.sumologic.com/Send_Data/Sources/02Sources_for_Hosted_Collectors/HTTP_Source)
 
@@ -20,7 +20,7 @@ First create an [HTTP collector endpoint](http://help.sumologic.com/Send_Data/So
    * Copy code from cloudwatchlogs_lambda.js into the Lambda function code.
    * Add Environment variables (See below)
 5. Scroll down to the `Lambda function handle and role` section, make sure you set the right values that match the function. For role, you can just use the basic execution role. Click next.
-6. Finally click on "Create function" to create the function. 
+6. Finally click on "Create function" to create the function.
 7. (Optional) Test this new function with sample AWS CloudWatch Logs template provided by AWS
 
 ## Create Stream from CloudWatch Logs
@@ -41,6 +41,7 @@ The following AWS Lambda environment variables are supported
 * `SOURCE_CATEGORY_OVERRIDE` (OPTIONAL) - Override _sourceCategory metadata field within SumoLogic. If `none` will not be overridden
 * `SOURCE_HOST_OVERRIDE` (OPTIONAL) - Override _sourceHost metadata field within SumoLogic. If `none` will not be overridden
 * `SOURCE_NAME_OVERRIDE` (OPTIONAL) - Override _sourceName metadata field within SumoLogic. If `none` will not be overridden
+* `LOG_STREAM_PREFIX` (OPTIONAL) - Comma separated list of logStream name prefixes to filter by logStream, expecially for AWS Batch logs
 
 # Dynamic Metadata Fields
 
@@ -52,7 +53,7 @@ For example:
 
 ```
 exports.handler = (event, context, callback) => {
-    
+
     var serverIp = '123.123.123.123'
 
     console.log(JSON.stringify({
@@ -62,7 +63,7 @@ exports.handler = (event, context, callback) => {
             'source': 'other_source',
             'host': serverIp
         }
-    
+
     }));
     console.log('some other log message with default sourceCategory');
 };

--- a/cloudwatchlogs/README.md
+++ b/cloudwatchlogs/README.md
@@ -41,7 +41,7 @@ The following AWS Lambda environment variables are supported
 * `SOURCE_CATEGORY_OVERRIDE` (OPTIONAL) - Override _sourceCategory metadata field within SumoLogic. If `none` will not be overridden
 * `SOURCE_HOST_OVERRIDE` (OPTIONAL) - Override _sourceHost metadata field within SumoLogic. If `none` will not be overridden
 * `SOURCE_NAME_OVERRIDE` (OPTIONAL) - Override _sourceName metadata field within SumoLogic. If `none` will not be overridden
-* `LOG_STREAM_PREFIX` (OPTIONAL) - Comma separated list of logStream name prefixes to filter by logStream, expecially for AWS Batch logs
+* `LOG_STREAM_PREFIX` (OPTIONAL) - Comma separated list of logStream name prefixes to filter by logStream, especially for AWS Batch logs
 
 # Dynamic Metadata Fields
 

--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -21,6 +21,11 @@ var encoding = process.env.ENCODING || 'utf-8';  // default is utf-8
 // Include logStream and logGroup as json fields within the message. Required for SumoLogic AWS Lambda App
 var includeLogInfo = false;  // default is false
 
+// Regex to filter by logStream name prefixes
+var logStreamPrefixRegex = process.env.LOG_STREAM_PREFIX
+                            ? new RegExp('^(' + process.env.LOG_STREAM_PREFIX.replace(/,/g, '|')  + ')', 'i')
+                            : '';
+
 // Regex used to detect logs coming from lambda functions.
 // The regex will parse out the requestID and strip the timestamp
 // Example: 2016-11-10T23:11:54.523Z	108af3bb-a79b-11e6-8bd7-91c363cc05d9    some message
@@ -158,6 +163,9 @@ exports.handler = function (event, context, callback) {
         if (awslogsData.messageType === 'CONTROL_MESSAGE') {
             console.log('Control message');
             callback(null, 'Success');
+        } else if(logStreamPrefixRegex && !awslogsData.logStream.match(logStreamPrefixRegex)){
+            console.log('Skipping Non-Applicable Log Stream');
+            return callback(null, 'Success');
         }
 
         var lastRequestID = null;

--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -23,7 +23,7 @@ var includeLogInfo = false;  // default is false
 
 // Regex to filter by logStream name prefixes
 var logStreamPrefixRegex = process.env.LOG_STREAM_PREFIX
-                            ? new RegExp('^(' + process.env.LOG_STREAM_PREFIX.replace(/,/g, '|')  + ')', 'i')
+                            ? new RegExp('^(' + escapeRegExp(process.env.LOG_STREAM_PREFIX).replace(/,/g, '|')  + ')', 'i')
                             : '';
 
 // Regex used to detect logs coming from lambda functions.
@@ -38,6 +38,9 @@ var https = require('https');
 var zlib = require('zlib');
 var url = require('url');
 
+function escapeRegExp(string) {
+  return string.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+}
 
 function sumoMetaKey(awslogsData, message) {
     var sourceCategory = '';


### PR DESCRIPTION
## Background

All of AWS Batch logs are sent to one log group, `/aws/batch/job`, and the log stream name format is `jobDefinitionName/default/ecs_task_id`:
https://docs.aws.amazon.com/batch/latest/userguide/job_states.html

## Changes

In order to stream logs of specific AWS Batch jobs to SumoLogic, this PR is adding log stream name prefix filtering for CloudWatch logs