### PR TITLE
added meta data field support

### DIFF
--- a/cloudwatchlogs-with-dlq/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs-with-dlq/cloudwatchlogs_lambda.js
@@ -70,11 +70,12 @@ function getConfig(env) {
         // SumoLogic Endpoint to post logs
         "SumoURL": env.SUMO_ENDPOINT,
 
-        // The following parameters override the sourceCategory, sourceHost and sourceName metadata fields within SumoLogic.
+        // The following parameters override the sourceCategory, sourceHost, sourceName and sourceFields metadata fields within SumoLogic.
         // Not these can also be overridden via json within the message payload. See the README for more information.
         "sourceCategoryOverride": ("SOURCE_CATEGORY_OVERRIDE" in env) ?  env.SOURCE_CATEGORY_OVERRIDE: '',  // If none sourceCategoryOverride will not be overridden
-        "sourceHostOverride": ("SOURCE_HOST_OVERRIDE" in env) ? env.SOURCE_HOST_OVERRIDE : '',          // If none sourceHostOverride will not be set to the name of the logGroup
-        "sourceNameOverride": ("SOURCE_NAME_OVERRIDE" in env) ? env.SOURCE_NAME_OVERRIDE : '',          // If none sourceNameOverride will not be set to the name of the logStream
+	"sourceFieldsOverride": ("SOURCE_FIELDS_OVERRIDE" in env) ?  env.SOURCE_FIELDS_OVERRIDE: '',        // If none sourceFieldsOverride will not be overridden
+        "sourceHostOverride": ("SOURCE_HOST_OVERRIDE" in env) ? env.SOURCE_HOST_OVERRIDE : '',              // If none sourceHostOverride will not be set to the name of the logGroup
+        "sourceNameOverride": ("SOURCE_NAME_OVERRIDE" in env) ? env.SOURCE_NAME_OVERRIDE : '',              // If none sourceNameOverride will not be set to the name of the logStream
         "SUMO_CLIENT_HEADER": env.SUMO_CLIENT_HEADER || 'cwl-aws-lambda',
         // CloudWatch logs encoding
         "encoding": env.ENCODING || 'utf-8',  // default is utf-8

--- a/cloudwatchlogs-with-dlq/sumo-dlq-function-utils/lib/sumologsclient.js
+++ b/cloudwatchlogs-with-dlq/sumo-dlq-function-utils/lib/sumologsclient.js
@@ -15,15 +15,17 @@ function SumoLogsClient(config) {
 
 SumoLogsClient.prototype.generateHeaders = function(config, message, awslogsData) {
     var sourceCategory = config.sourceCategoryOverride || '';
+    var sourceFields = config.sourceFieldsOverride || '';
     var sourceName = config.sourceNameOverride || ((awslogsData) ? awslogsData.logStream : '');
     var sourceHost = config.sourceHostOverride || ((awslogsData) ? awslogsData.logGroup : '');
 
     var headerObj = {
         'X-Sumo-Name':sourceName, 'X-Sumo-Category':sourceCategory,
-        'X-Sumo-Host':sourceHost, 'X-Sumo-Client': config.SUMO_CLIENT_HEADER
+        'X-Sumo-Host':sourceHost, 'X-Sumo-Fields':sourceFields,
+        'X-Sumo-Client': config.SUMO_CLIENT_HEADER
     };
 
-    var metadataMap = {category: "X-Sumo-Category", sourceName: "X-Sumo-Name", sourceHost: "X-Sumo-Host"};
+    var metadataMap = {category: "X-Sumo-Category", sourceName: "X-Sumo-Name", sourceHost: "X-Sumo-Host", sourceFieldsOverride: "X-Sumo-Fields"};
     if (message.hasOwnProperty('_sumo_metadata')) {
         var metadataOverride = message._sumo_metadata;
         Object.getOwnPropertyNames(metadataOverride).forEach( function(property) {
@@ -47,6 +49,7 @@ SumoLogsClient.prototype.createPromises = function(messages, is_compressed) {
             'X-Sumo-Name': headerArray[0],
             'X-Sumo-Category': headerArray[1],
             'X-Sumo-Host': headerArray[2],
+            'X-Sumo-Fields': headerArray[3],
             'X-Sumo-Client': self.SUMO_CLIENT_HEADER
         };
         var options = Object.assign({}, self.options);
@@ -100,7 +103,7 @@ SumoLogsClient.prototype.postToSumo = function(messages, is_compressed) {
 };
 
 SumoLogsClient.prototype.getMetaDataKey = function(headerObj) {
-    return headerObj['X-Sumo-Name'] + ':' + headerObj['X-Sumo-Category'] + ':' + headerObj['X-Sumo-Host'];
+    return headerObj['X-Sumo-Name'] + ':' + headerObj['X-Sumo-Category'] + ':' + headerObj['X-Sumo-Host'] + ':' + headerObj['X-Sumo-Fields'];
 };
 
 


### PR DESCRIPTION
Added the ability to provide field values for our new metadata fields by specifying an environment variable.

SOURCE_FIELDS_OVERRIDE
with a comma separated list like the following
environment=prod,log_type=vpc