### PR TITLE
SUMO-140669: Added tag filtering

### DIFF
--- a/loggroup-lambda-connector/Readme.md
+++ b/loggroup-lambda-connector/Readme.md
@@ -12,6 +12,7 @@ Made with ❤️ by Sumo Logic. Available on the [AWS Serverless Application Rep
         LambdaARN: "Enter ARN for target lambda function" All loggroups matching the pattern are subscribed to this function
         LogGroupPattern: "Enter regex for matching logGroups"
         UseExistingLogs: "Select true for subscribing existing logs"
+        LogGroupTags: "Enter comma separated keyvalue pairs for filtering logGroups using tags. Ex KeyName1=string,KeyName2=string. Supported only when UseExistingLogs is set to false."
     6. Click Deploy.
 
 
@@ -42,6 +43,8 @@ It has two environment variables
 ```
 
 **USE_EXISTING_LOGS**: This is used for subscribing existing log groups. By setting this parameter to true and invoking the function manually, all the existing log groups matching the pattern will be subscribed to lambda function with `LAMBDA_ARN` as arn
+
+**LogGroupTags**: This is used for filtering out loggroups based on tags.Only loggroups which match any one of the key value pairs will be subscribed to the lambda function. This works only for new loggroups not existing loggroups.
 
 ### For Developers
 

--- a/loggroup-lambda-connector/sam/packaged.yaml
+++ b/loggroup-lambda-connector/sam/packaged.yaml
@@ -21,10 +21,10 @@ Metadata:
     - serverless
     - loggroups
     - cloudwatch
-    LicenseUrl: s3://appdevstore/LoggroupConnector/v1.0.2/5122657d5b9a0d3713e24d3a33eae431
+    LicenseUrl: s3://appdevstore/LoggroupConnector/v1.0.3/5122657d5b9a0d3713e24d3a33eae431
     Name: sumologic-loggroup-connector
-    ReadmeUrl: s3://appdevstore/LoggroupConnector/v1.0.2/0490ecc943c35a5d04b00813554c06ad
-    SemanticVersion: 1.0.2
+    ReadmeUrl: s3://appdevstore/LoggroupConnector/v1.0.3/c98f2c0d986a3f55fbea539688ee6a2e
+    SemanticVersion: 1.0.3
     SourceCodeUrl: https://github.com/SumoLogic/sumologic-aws-lambda/loggroup-lambda-connector
     SpdxLicenseId: Apache-2.0
 Parameters:
@@ -43,11 +43,15 @@ Parameters:
     - 'true'
     - 'false'
     Description: Select true for subscribing existing logs
+  LogGroupTags:
+    Type: CommaDelimitedList
+    Description: 'Enter comma separated keyvalue pairs for filtering logGroups using
+      tags. Ex KeyName1=string,KeyName2=string '
 Resources:
   SumoLogGroupLambdaConnector:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: s3://appdevstore/LoggroupConnector/v1.0.2/06605e5d4a1e561027da885250b6d539
+      CodeUri: s3://appdevstore/LoggroupConnector/v1.0.3/fef3de66919bef9861be16f25aec0343
       Handler: loggroup-lambda-connector.handler
       Runtime: nodejs10.x
       Environment:
@@ -58,6 +62,10 @@ Resources:
             Ref: LogGroupPattern
           USE_EXISTING_LOG_GROUPS:
             Ref: UseExistingLogs
+          LOG_GROUP_TAGS:
+            Fn::Join:
+            - ','
+            - Ref: LogGroupTags
       Policies:
       - Statement:
         - Sid: ReadWriteFilterPolicy

--- a/loggroup-lambda-connector/sam/sam_package.sh
+++ b/loggroup-lambda-connector/sam/sam_package.sh
@@ -8,11 +8,14 @@ else
     SAM_S3_BUCKET="cf-templates-5d0x5unchag-us-east-2"
     AWS_REGION="us-east-2"
 fi
-sam package --template-file template.yaml --s3-bucket $SAM_S3_BUCKET  --output-template-file packaged.yaml --s3-prefix LoggroupConnector/v1.0.2
 
-# sam deploy --template-file packaged.yaml --stack-name testingloggrpconnector --capabilities CAPABILITY_IAM --region $AWS_REGION  --parameter-overrides LambdaARN="arn:aws:lambda:us-east-1:956882708938:function:AccessVPCResourcesLambda"
+version="1.0.3"
 
-sam publish --template packaged.yaml --region us-east-1
+sam package --template-file template.yaml --s3-bucket $SAM_S3_BUCKET  --output-template-file packaged.yaml --s3-prefix "LoggroupConnector/v$version"
+
+sam deploy --template-file packaged.yaml --stack-name testingloggrpconnector --capabilities CAPABILITY_IAM --region $AWS_REGION  --parameter-overrides LambdaARN="arn:aws:lambda:us-east-1:956882708938:function:SumoCWLogsLambda" LogGroupTags="env=prod,name=apiassembly" LogGroupPattern="test"
+
+# sam publish --template packaged.yaml --region $AWS_REGION --semantic-version $version
 # aws cloudformation describe-stack-events --stack-name testingloggrpconnector --region $AWS_REGION
 # aws cloudformation get-template --stack-name testingloggrpconnector  --region $AWS_REGION
 

--- a/loggroup-lambda-connector/sam/template.yaml
+++ b/loggroup-lambda-connector/sam/template.yaml
@@ -24,7 +24,7 @@ Metadata:
     LicenseUrl: ./LICENSE
     Name: sumologic-loggroup-connector
     ReadmeUrl: ../README.md
-    SemanticVersion: 1.0.2
+    SemanticVersion: 1.0.3
     SourceCodeUrl: https://github.com/SumoLogic/sumologic-aws-lambda/loggroup-lambda-connector
     SpdxLicenseId: Apache-2.0
 
@@ -45,6 +45,10 @@ Parameters:
         AllowedValues : ["true", "false"]
         Description: "Select true for subscribing existing logs"
 
+    LogGroupTags:
+        Type: CommaDelimitedList
+        Description: "Enter comma separated keyvalue pairs for filtering logGroups using tags. Ex KeyName1=string,KeyName2=string "
+
 Resources:
 
     SumoLogGroupLambdaConnector:
@@ -58,6 +62,7 @@ Resources:
             LAMBDA_ARN: !Ref "LambdaARN"
             LOG_GROUP_PATTERN: !Ref "LogGroupPattern"
             USE_EXISTING_LOG_GROUPS: !Ref "UseExistingLogs"
+            LOG_GROUP_TAGS: !Join [",", {"Ref": "LogGroupTags"} ]
         Policies:
           - Statement:
             - Sid: ReadWriteFilterPolicy

--- a/loggroup-lambda-connector/src/loggroup-lambda-connector.js
+++ b/loggroup-lambda-connector/src/loggroup-lambda-connector.js
@@ -18,12 +18,25 @@ function subscribeToLambda(lambdaLogGroupName, lambdaArn, errorHandler) {
 
 function filterLogGroups(event, logGroupRegex) {
     logGroupRegex = new RegExp(logGroupRegex, "i");
-    var logGroupName = event.detail.requestParameters.logGroupName;
+    let logGroupName = event.detail.requestParameters.logGroupName;
     if (logGroupName.match(logGroupRegex) && event.detail.eventName === "CreateLogGroup") {
         return true;
-    } else {
-        return false;
     }
+    let lg_tags = event.detail.requestParameters.tags;
+    if (process.env.LOG_GROUP_TAGS && lg_tags) {
+        console.log("tags in loggroup: ", lg_tags);
+        var tags_array = process.env.LOG_GROUP_TAGS.split(",");
+        let tag, key, value;
+        for (let i = 0; i < tags_array.length; i++) {
+          tag = tags_array[i].split("=");
+          key = tag[0].trim();
+          value = tag[1].trim();
+          if (lg_tags[key] && lg_tags[key]==value) {
+              return true;
+          }
+        }
+    }
+    return false;
 }
 
 async function subscribeExistingLogGroups(logGroups) {


### PR DESCRIPTION
Added a new parameter LogGroupTags which is used for filtering out loggroups based on tags. Only loggroups which match any one of the key value pairs will be subscribed to the lambda function. This works only for new loggroups not existing loggroups.
