### PR TITLE
Cloudwatchlogs fix hostname

### DIFF
--- a/cloudwatchlogs/cloudwatchlogs_lambda.js
+++ b/cloudwatchlogs/cloudwatchlogs_lambda.js
@@ -111,9 +111,9 @@ function postToSumo(callback, messages) {
         var headerArray = key.split(':');
 
         options.headers = {
-            'X-Sumo-Name': headerArray[0],
+            'X-Sumo-Name': headerArray[2],
             'X-Sumo-Category': headerArray[1],
-            'X-Sumo-Host': headerArray[2],
+            'X-Sumo-Host': headerArray[0],
             'X-Sumo-Client': 'cwl-aws-lambda'
         };
 


### PR DESCRIPTION
Before: 
`Host: /aws/elasticbeanstalk/var/log/httpd/access_log  Name: i-02cd231ee30150f88  Category: apache `

After: 
`Host: i-02cd231ee30150f88  Name: /aws/elasticbeanstalk/var/log/httpd/access_log  Category: apache `