### PR TITLE
cloudwatchlogs-with-dlq: support optional kms key for encrypting sns topics

### DIFF
--- a/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
+++ b/cloudwatchlogs-with-dlq/DLQLambdaCloudFormation.json
@@ -12,6 +12,11 @@
         "Default": "test@gmail.com",
         "Description": "Enter your email for receiving alerts.You will receive confirmation email after the deployment is complete, confirm it to subscribe for alerts."
       },
+      "SNSTopicKMSKey": {
+        "Type": "String",
+        "Default": "",
+        "Description": "Optional KMS key id to encrypt messages on the email SNS topic."
+      },
       "NumOfWorkers": {
         "Type": "Number",
         "Default": 4,
@@ -62,6 +67,9 @@
             "ap-northeast-3": {"bucketname": "appdevzipfiles-ap-northeast-3s"},
             "ap-southeast-3": {"bucketname": "appdevzipfiles-ap-southeast-3"}
         }
+    },
+    "Conditions": {
+        "HasSNSTopicKey": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SNSTopicKMSKey" }, "" ] } ] }
     },
     "Resources": {
         "SumoCWLogGroup": {
@@ -322,7 +330,8 @@
                 "Subscription":[ {
                     "Endpoint" : {"Ref": "EmailID"},
                     "Protocol" : "email"
-                }]
+                }],
+                "KmsMasterKeyId": { "Fn::If" : [ "HasSNSTopicKey", { "Ref": "SNSTopicKMSKey" }, { "Ref": "AWS::NoValue" } ] }
             }
         },
         "SumoCWSpilloverAlarm":{

--- a/cloudwatchlogs-with-dlq/DLQLambdaCloudFormationWithSecuredEndpoint.json
+++ b/cloudwatchlogs-with-dlq/DLQLambdaCloudFormationWithSecuredEndpoint.json
@@ -12,6 +12,11 @@
         "Default": "test@gmail.com",
         "Description": "Enter your email for receiving alerts.You will receive confirmation email after the deployment is complete, confirm it to subscribe for alerts."
       },
+      "SNSTopicKMSKey": {
+        "Type": "String",
+        "Default": "",
+        "Description": "Optional KMS key id to encrypt messages on the email SNS topic."
+      },
       "NumOfWorkers": {
         "Type": "Number",
         "Default": 4,
@@ -62,6 +67,9 @@
             "ap-northeast-3": {"bucketname": "appdevzipfiles-ap-northeast-3s"},
             "ap-southeast-3": {"bucketname": "appdevzipfiles-ap-southeast-3"}
         }
+    },
+    "Conditions": {
+        "HasSNSTopicKey": { "Fn::Not": [ { "Fn::Equals": [ { "Ref": "SNSTopicKMSKey" }, "" ] } ] }
     },
     "Resources": {
         "SumoCWLogGroup": {
@@ -362,7 +370,8 @@
                 "Subscription":[ {
                     "Endpoint" : {"Ref": "EmailID"},
                     "Protocol" : "email"
-                }]
+                }],
+                "KmsMasterKeyId": { "Fn::If" : [ "HasSNSTopicKey", { "Ref": "SNSTopicKMSKey" }, { "Ref": "AWS::NoValue" } ] }
             }
         },
         "SumoCWSpilloverAlarm":{


### PR DESCRIPTION
Currently the SNS topics created by these templates are unencrypted. This PR adds optional encryption for the topics when a KMS key id is specified. This id can be the literal id, or something like `alias/aws/sns`. This is a non-breaking change. Existing CloudFormation stacks that are updated with this template will produce no changes unless the SNSTopicKMSKey parameter is explicitly specified.